### PR TITLE
Fix build image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-AMZ_LINUX_VERSION:=latest
+AMZ_LINUX_VERSION:=2018.03.0.20180622
 current_dir := $(shell pwd)
 container_dir := /opt/app
 circleci := ${CIRCLECI}


### PR DESCRIPTION
That's related to https://github.com/upsidetravel/bucket-antivirus-function/issues/40