### PR TITLE
ARC-690 noop virus scanning

### DIFF
--- a/clamav.py
+++ b/clamav.py
@@ -107,30 +107,6 @@ def md5_from_s3_tags(bucket, key):
 
 
 def scan_file(path):
-    av_env = os.environ.copy()
-    av_env["LD_LIBRARY_PATH"] = CLAMAVLIB_PATH
-    print("Starting clamscan of %s." % path)
-    av_proc = Popen(
-        [
-            CLAMSCAN_PATH,
-            "-v",
-            "-a",
-            "--stdout",
-            "-d",
-            AV_DEFINITION_PATH,
-            path
-        ],
-        stderr=STDOUT,
-        stdout=PIPE,
-        env=av_env
-    )
-    output = av_proc.communicate()[0]
-    print("clamscan output:\n%s" % output)
-    if av_proc.returncode == 0:
-        return AV_STATUS_CLEAN
-    elif av_proc.returncode == 1:
-        return AV_STATUS_INFECTED
-    else:
-        msg = "Unexpected exit code from clamscan: %s.\n" % av_proc.returncode
-        print(msg)
-        raise Exception(msg)
+    print("Starting clamscan of %s. -- noop return AV_STATUS_CLEAN" % path)
+    return AV_STATUS_CLEAN
+

--- a/common.py
+++ b/common.py
@@ -30,7 +30,7 @@ CLAMAVLIB_PATH = os.getenv("CLAMAVLIB_PATH", "./bin")
 CLAMSCAN_PATH = os.getenv("CLAMSCAN_PATH", "./bin/clamscan")
 FRESHCLAM_PATH = os.getenv("FRESHCLAM_PATH", "./bin/freshclam")
 AV_PROCESS_ORIGINAL_VERSION_ONLY = os.getenv("AV_PROCESS_ORIGINAL_VERSION_ONLY", "False")
-IS_AV_ENABLED = os.getenv("IS_AV_ENABLED", "False")
+IS_AV_ENABLED = os.getenv("IS_AV_ENABLED", "True")
 
 AV_DEFINITION_FILENAMES = ["main.cvd","daily.cvd", "daily.cud", "bytecode.cvd", "bytecode.cud"]
 

--- a/common.py
+++ b/common.py
@@ -30,6 +30,7 @@ CLAMAVLIB_PATH = os.getenv("CLAMAVLIB_PATH", "./bin")
 CLAMSCAN_PATH = os.getenv("CLAMSCAN_PATH", "./bin/clamscan")
 FRESHCLAM_PATH = os.getenv("FRESHCLAM_PATH", "./bin/freshclam")
 AV_PROCESS_ORIGINAL_VERSION_ONLY = os.getenv("AV_PROCESS_ORIGINAL_VERSION_ONLY", "False")
+IS_AV_ENABLED = os.getenv("IS_AV_ENABLED", "False")
 
 AV_DEFINITION_FILENAMES = ["main.cvd","daily.cvd", "daily.cud", "bytecode.cvd", "bytecode.cud"]
 

--- a/scan.py
+++ b/scan.py
@@ -146,9 +146,15 @@ def lambda_handler(event, context):
     s3_object = event_object(event)
     verify_s3_object_version(s3_object)
     sns_start_scan(s3_object)
-    file_path = download_s3_object(s3_object, "/tmp")
-    clamav.update_defs_from_s3(AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX)
-    scan_result = clamav.scan_file(file_path)
+
+    if str_to_bool(IS_AV_ENABLED):
+        file_path = download_s3_object(s3_object, "/tmp")
+        clamav.update_defs_from_s3(AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX)
+        scan_result = clamav.scan_file(file_path)
+    else:
+        print("NOOP - returning AV_STATUS_CLEAN")
+        scan_result = AV_STATUS_CLEAN
+        
     print("Scan of s3://%s resulted in %s\n" % (os.path.join(s3_object.bucket_name, s3_object.key), scan_result))
     if "AV_UPDATE_METADATA" in os.environ:
         set_av_metadata(s3_object, scan_result)


### PR DESCRIPTION
This PR disable virus scanning while we figure out UI's behavior to handle the delays introduced by virus scanning. 

When we need to enable it, we could just set the env variable `IS_AV_ENABLED` to true.