### PR TITLE
ARC-1304 removed downloading part of freshclam

### DIFF
--- a/update.py
+++ b/update.py
@@ -22,7 +22,7 @@ def lambda_handler(event, context):
     start_time = datetime.utcnow()
     print("Script starting at %s\n" %
           (start_time.strftime("%Y/%m/%d %H:%M:%S UTC")))
-    clamav.update_defs_from_s3(AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX)
+    # clamav.update_defs_from_s3(AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX)
     clamav.update_defs_from_freshclam(AV_DEFINITION_PATH, CLAMAVLIB_PATH)
     # If main.cvd gets updated (very rare), we will need to force freshclam
     # to download the compressed version to keep file sizes down.


### PR DESCRIPTION
This issue was related to the fact that `freshclam` creates `cld` files rather `cvd` files if `cvd` files are available in its local workspace. To fix this issue, I commented out the part the update lambda downloads the `cvd` files from our s3 buckets to its local workspace; this forces `freshclam` to downloads the remote `cvd` files.

see: http://lists.clamav.net/pipermail/clamav-users/2014-July/000621.

The following is the update lambda logs with some extra logging when it was not working. See the **bold** logs for the contents of `freshclam`'s workspace.

------------------------------------------------------
START RequestId: c04f54b4-95d4-11e8-b0a7-8be37fc43409 Version: $LATEST
Script starting at 2018/08/01 21:49:23 UTC

Attempting to create directiory /tmp/clamav_defs.

Downloading definition file main.cvd from s3://upgrade-av-definition-dev/clamav_defs to /tmp/clamav_defs/main.cvd
Downloading definition file daily.cvd from s3://upgrade-av-definition-dev/clamav_defs to /tmp/clamav_defs/daily.cvd
Downloading definition file bytecode.cvd from s3://upgrade-av-definition-dev/clamav_defs to /tmp/clamav_defs/bytecode.cvd
1) **['bytecode.cvd', 'daily.cvd', 'main.cvd']**
Starting freshclam with defs in /tmp/clamav_defs.
freshclam output:
ClamAV update process started at Wed Aug 1 21:49:27 2018
WARNING: Your ClamAV installation is OUTDATED!
WARNING: Local version: 0.99.4 Recommended version: 0.100.1
DON'T PANIC! Read http://www.clamav.net/documents/upgrading-clamav
main.cvd is up to date (version: 58, sigs: 4566249, f-level: 60, builder: sigmgr)
Downloading daily-24798.cdiff [100%]
Downloading daily-24799.cdiff [100%]
Downloading daily-24800.cdiff [100%]
Downloading daily-24801.cdiff [100%]
Downloading daily-24802.cdiff [100%]
Downloading daily-24803.cdiff [100%]
daily.cld updated (version: 24803, sigs: 2034540, f-level: 63, builder: neo)
Downloading bytecode-320.cdiff [100%]
Downloading bytecode-321.cdiff [100%]
Downloading bytecode-322.cdiff [100%]
Downloading bytecode-323.cdiff [100%]
Downloading bytecode-324.cdiff [100%]
Downloading bytecode-325.cdiff [100%]
Downloading bytecode-326.cdiff [100%]
bytecode.cld updated (version: 326, sigs: 93, f-level: 63, builder: neo)
Database updated (6600882 signatures) from database.clamav.net (IP: 104.16.186.138)

2) **['daily.cld', 'bytecode.cld', 'mirrors.dat', 'main.cvd']**
filename=main.cvd local_file_md5=a22e1b59c5e8b8eff166271b08b4ad72 remote_file_md5=a22e1b59c5e8b8eff166271b08b4ad72
Not uploading main.cvd because md5 on remote matches local.
local file not found: /tmp/clamav_defs/daily.cvd
local file not found: /tmp/clamav_defs/daily.cud
local file not found: /tmp/clamav_defs/bytecode.cvd
local file not found: /tmp/clamav_defs/bytecode.cud
**3) ['daily.cld', 'bytecode.cld', 'mirrors.dat', 'main.cvd']**
Script finished at 2018/08/01 21:49:43 UTC
END RequestId: c04f54b4-95d4-11e8-b0a7-8be37fc43409
REPORT RequestId: c04f54b4-95d4-11e8-b0a7-8be37fc43409	Duration: 19425.47 ms	Billed Duration: 19500 ms Memory Size: 1024 MB	Max Memory Used: 606 MB	
------------------------------------------------------