### PR TITLE
TOP-6042 uses centos rather than amazon linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CENT_OS_VERSION:=centos7.6.1810
+LINUX_DOCKER_IMAGE:=docker-upgrade.artifactory.build.upgrade.com/container-base:2.0.20190212-15
 current_dir := $(shell pwd)
 container_dir := /opt/app
 circleci := ${CIRCLECI}
@@ -27,12 +27,14 @@ ifeq ($(circleci), true)
 	docker create -v $(container_dir) --name src alpine:3.4 /bin/true
 	docker cp $(current_dir)/. src:$(container_dir)
 	docker run --rm \
+		--user root \
 		--volumes-from src \
-		centos:$(CENT_OS_VERSION) \
+		$(LINUX_DOCKER_IMAGE) \
 		/bin/bash -c "cd $(container_dir) && ./build_lambda.sh"
 else
 	docker run --rm \
+		--user root \
 		-v $(current_dir):$(container_dir) \
-		centos:$(CENT_OS_VERSION) \
+		$(LINUX_DOCKER_IMAGE) \
 		/bin/bash -c "cd $(container_dir) && ./build_lambda.sh"
 endif

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-AMZ_LINUX_VERSION:=2018.03.0.20180622
+CENT_OS_VERSION:=centos7.6.1810
 current_dir := $(shell pwd)
 container_dir := /opt/app
 circleci := ${CIRCLECI}
@@ -28,11 +28,11 @@ ifeq ($(circleci), true)
 	docker cp $(current_dir)/. src:$(container_dir)
 	docker run --rm \
 		--volumes-from src \
-		amazonlinux:$(AMZ_LINUX_VERSION) \
+		centos:$(CENT_OS_VERSION) \
 		/bin/bash -c "cd $(container_dir) && ./build_lambda.sh"
 else
 	docker run --rm \
 		-v $(current_dir):$(container_dir) \
-		amazonlinux:$(AMZ_LINUX_VERSION) \
+		centos:$(CENT_OS_VERSION) \
 		/bin/bash -c "cd $(container_dir) && ./build_lambda.sh"
 endif

--- a/build_lambda.sh
+++ b/build_lambda.sh
@@ -19,8 +19,11 @@ lambda_output_file=/opt/app/build/lambda.zip
 set -e
 
 yum update -y
-yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum install -y cpio python2-pip zip pcre2 json-c
+amazon-linux-extras enable epel
+yum clean metadata
+yum install -y epel-release
+yum install -y yum-utils
 pip install --no-cache-dir virtualenv
 virtualenv env
 . env/bin/activate

--- a/build_lambda.sh
+++ b/build_lambda.sh
@@ -19,7 +19,8 @@ lambda_output_file=/opt/app/build/lambda.zip
 set -e
 
 yum update -y
-yum install -y cpio python27-pip zip
+yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum install -y cpio python2-pip zip pcre2 json-c
 pip install --no-cache-dir virtualenv
 virtualenv env
 . env/bin/activate
@@ -32,7 +33,7 @@ rpm2cpio clamav-lib*.rpm | cpio -idmv
 rpm2cpio clamav-update*.rpm | cpio -idmv
 popd
 mkdir -p bin
-cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* bin/.
+cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/libjson-c.so.2 /usr/lib64/libpcre2-8.so.0 bin/.
 echo "DatabaseMirror database.clamav.net" > bin/freshclam.conf
 
 mkdir -p build


### PR DESCRIPTION
This PR changes the way the lambda package is prepared so that it uses CentOS rather than Amazon Linux. The reason behind this change is that Amazon's rpm repository doesn't include the latest ClamAV. Also, I could not find an easy way to use epel7 in Amazon Linux env to install ClamAV.