### PR TITLE
ARC-2708: Fixed silent failures while updating virus definitions

### DIFF
--- a/update.py
+++ b/update.py
@@ -56,7 +56,7 @@ def lambda_handler(event, context):
             os.remove(os.path.join(AV_DEFINITION_PATH, "main.cvd"))
         retVal = clamav.update_defs_from_freshclam(AV_DEFINITION_PATH, CLAMAVLIB_PATH)
         if retVal != 0:
-            raise RuntimeError("clamAV update process returned %d" % (retVal))
+            raise RuntimeError("Refresh clamAV update process returned %d" % (retVal))
     clamav.upload_defs_to_s3(
         s3_client, AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX, AV_DEFINITION_PATH
     )

--- a/update.py
+++ b/update.py
@@ -44,7 +44,9 @@ def lambda_handler(event, context):
         s3.Bucket(AV_DEFINITION_S3_BUCKET).download_file(s3_path, local_path)
         print("Downloading definition file %s complete!" % (local_path))
 
-    clamav.update_defs_from_freshclam(AV_DEFINITION_PATH, CLAMAVLIB_PATH)
+    retVal = clamav.update_defs_from_freshclam(AV_DEFINITION_PATH, CLAMAVLIB_PATH)
+    if retVal != 0:
+        raise RuntimeError("clamAV update process returned %d" % (retVal))
     # If main.cvd gets updated (very rare), we will need to force freshclam
     # to download the compressed version to keep file sizes down.
     # The existence of main.cud is the trigger to know this has happened.
@@ -52,7 +54,9 @@ def lambda_handler(event, context):
         os.remove(os.path.join(AV_DEFINITION_PATH, "main.cud"))
         if os.path.exists(os.path.join(AV_DEFINITION_PATH, "main.cvd")):
             os.remove(os.path.join(AV_DEFINITION_PATH, "main.cvd"))
-        clamav.update_defs_from_freshclam(AV_DEFINITION_PATH, CLAMAVLIB_PATH)
+        retVal = clamav.update_defs_from_freshclam(AV_DEFINITION_PATH, CLAMAVLIB_PATH)
+        if retVal != 0:
+            raise RuntimeError("clamAV update process returned %d" % (retVal))
     clamav.upload_defs_to_s3(
         s3_client, AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX, AV_DEFINITION_PATH
     )


### PR DESCRIPTION
### Ticket

https://credify.atlassian.net/browse/ARC-2708

### Description

The goal of this PR is to throw an exception when clamAv update process returns a non 0 value.
