### PR TITLE
ARC-2708: Fixed disk space error in virus definition updates

### DIFF
--- a/update.py
+++ b/update.py
@@ -34,11 +34,8 @@ def lambda_handler(event, context):
     start_time = datetime.utcnow()
     print("Script starting at %s\n" % (start_time.strftime("%Y/%m/%d %H:%M:%S UTC")))
 
-    for root, dirs, files in os.walk(AV_DEFINITION_PATH):
-        for f in files:
-            os.unlink(os.path.join(root, f))
-        for d in dirs:
-            shutil.rmtree(os.path.join(root, d))
+    shutil.rmtree(AV_DEFINITION_PATH)
+    os.mkdir(AV_DEFINITION_PATH)
 
     to_download = clamav.update_defs_from_s3(
         s3_client, AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX

--- a/update.py
+++ b/update.py
@@ -24,6 +24,7 @@ from common import AV_DEFINITION_S3_PREFIX
 from common import CLAMAVLIB_PATH
 from common import get_timestamp
 from datetime import datetime
+import shutil
 
 
 def lambda_handler(event, context):
@@ -31,18 +32,25 @@ def lambda_handler(event, context):
     s3_client = boto3.client("s3")
 
     start_time = datetime.utcnow()
-    print("Script starting at %s\n" %
-              (start_time.strftime("%Y/%m/%d %H:%M:%S UTC")))
+    print("Script starting at %s\n" % (start_time.strftime("%Y/%m/%d %H:%M:%S UTC")))
+
+    for root, dirs, files in os.walk(AV_DEFINITION_PATH):
+        for f in files:
+            os.unlink(os.path.join(root, f))
+        for d in dirs:
+            shutil.rmtree(os.path.join(root, d))
+
     to_download = clamav.update_defs_from_s3(
         s3_client, AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX
     )
 
-    for download in to_download.values():
-        s3_path = download["s3_path"]
-        local_path = download["local_path"]
-        print("Downloading definition file %s from s3://%s" % (local_path, s3_path))
-        s3.Bucket(AV_DEFINITION_S3_BUCKET).download_file(s3_path, local_path)
-        print("Downloading definition file %s complete!" % (local_path))
+    print("Skipping clamav definition download %s\n" % (get_timestamp()))
+    # for download in to_download.values():
+    #    s3_path = download["s3_path"]
+    #    local_path = download["local_path"]
+    #    print("Downloading definition file %s from s3://%s" % (local_path, s3_path))
+    #    s3.Bucket(AV_DEFINITION_S3_BUCKET).download_file(s3_path, local_path)
+    #    print("Downloading definition file %s complete!" % (local_path))
 
     clamav.update_defs_from_freshclam(AV_DEFINITION_PATH, CLAMAVLIB_PATH)
     # If main.cvd gets updated (very rare), we will need to force freshclam


### PR DESCRIPTION
### Ticket

https://credify.atlassian.net/browse/ARC-2708

### Description

The goal of this PR is to fix the virus definition updates.
This fix has been proposed in https://github.com/upsidetravel/bucket-antivirus-function/issues/130#issuecomment-657645120 (and some other discussions).

Hypothesis of this failure is that lambda is running out of disk space: Amazon Lambda max disk space is 512MB, latest definitions are now over 300Mb.

Current flow:
- download existing virus definitions from s3
- launch freshclam
    - download latest virus definitions
- compare hashes
- if they are different upload the new version


New flow:
- delete existing local virus definitions (in case of lambda env being reused multiple times)
- launch freshclam
    - download latest virus definitions
- compare hashes
- if they are different upload the new version
