### PR TITLE
ARC-2729: Fix error while decoding clamAV output

### DIFF
--- a/clamav.py
+++ b/clamav.py
@@ -194,7 +194,7 @@ def scan_file(path):
         stdout=subprocess.PIPE,
         env=av_env,
     )
-    output = av_proc.communicate()[0].decode()
+    output = av_proc.communicate()[0].decode(encoding="utf-8", errors="replace")
     print("clamscan output:\n%s" % output)
 
     # Turn the output into a data source we can read


### PR DESCRIPTION
### Ticket

https://credify.atlassian.net/browse/ARC-2729

### Description

The goal of this PR is to fix a decoding error that happens when clamav process' output contains non utf-8 chars.
