### PR TITLE
ARC-2708: Fixed FileNotFoundError

### DIFF
--- a/update.py
+++ b/update.py
@@ -34,8 +34,9 @@ def lambda_handler(event, context):
     start_time = datetime.utcnow()
     print("Script starting at %s\n" % (start_time.strftime("%Y/%m/%d %H:%M:%S UTC")))
 
-    shutil.rmtree(AV_DEFINITION_PATH)
-    os.mkdir(AV_DEFINITION_PATH)
+    if os.path.isdir(AV_DEFINITION_PATH):
+        shutil.rmtree(AV_DEFINITION_PATH)
+        os.mkdir(AV_DEFINITION_PATH)
 
     to_download = clamav.update_defs_from_s3(
         s3_client, AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX


### PR DESCRIPTION
### Description

The goal of this PR is to fix the FileNotFoundError that happens when definition directory was not existing 
(following https://github.com/Credify/bucket-antivirus-function/pull/18)

