### PR TITLE
PSE-436 - Updating to python 3.11 and bumping some libraries (CVE-2023-45803)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN cp /var/cache/dnf/usr/bin/clamscan /var/cache/dnf/usr/bin/freshclam /var/cac
 RUN echo "DatabaseMirror database.clamav.net" > /clamav/freshclam.conf && \
     echo "CompressLocalDatabase yes" >> /clamav/freshclam.conf
 
-FROM docker-release.artifactory.build.upgrade.com/python-base-2023:2.0.20240426.0-83.3.8-129
+FROM docker-release.artifactory.build.upgrade.com/python311-base:2.0.20240412.0-81-2
 
 USER root
 
@@ -62,6 +62,6 @@ RUN cp /var/task/bin/* /var/task/lib -r
 ENV LD_LIBRARY_PATH=/var/task/lib
 RUN ldconfig
 
-RUN pip3 install --no-cache-dir -r requirements.txt --target /var/task awslambdaric
+RUN pip3.11 install --no-cache-dir -r requirements.txt --target /var/task awslambdaric
 
-ENTRYPOINT [ "python", "-m", "awslambdaric" ]
+ENTRYPOINT [ "python3.11", "-m", "awslambdaric" ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ decorator==5.1.1
 idna==3.4
 requests==2.31.0
 simplejson==3.18.4
-urllib3==1.26.17
+urllib3==1.26.18
 pytz==2023.3
 python-magic
-boto3==1.28.63
-botocore==1.31.63
+boto3==1.34.102
+botocore==1.34.102


### PR DESCRIPTION
Already tested in stage.
QA Tests:
https://qa-jenkins.kube.usw2.services.upgrade.com/job/qa-jobs/job/miscellaneous/job/qa-run-tests-against-pullrequest/8114/
_There was one failed test (diff file not found). I think is unstable because I ran it again and worked._
https://qa-jenkins.kube.usw2.services.upgrade.com/job/qa-jobs/job/miscellaneous/job/qa-run-tests-against-pullrequest/8116/



Logs:
<img width="1172" alt="Screenshot 2024-05-10 at 2 01 22 PM" src="https://github.com/Credify/bucket-antivirus-function/assets/101131250/8b46a224-1b45-40dd-aff0-72c41758450d">
