### PR TITLE
PSE-865 Bumping request lib due to CVE-2024-35195

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ chardet==5.1.0
 datadog==0.45.0
 decorator==5.1.1
 idna==3.7
-requests==2.31.0
+requests==2.32.0
 simplejson==3.18.4
 urllib3==1.26.18
 pytz==2023.3


### PR DESCRIPTION
Already tested in stage:
<img width="1148" alt="Screenshot 2024-07-17 at 3 28 55 PM" src="https://github.com/user-attachments/assets/c808305e-ea66-4810-9df9-18e605742148">
