### PR TITLE
TOP-30850-fix-deprecated-lib-clamav

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,33 +14,50 @@ FROM 118455887602.dkr.ecr.us-west-2.amazonaws.com/releases/images/container-base
 
 USER root
 
-# Install packages
-RUN dnf install -y cpio less
+# Install packages and build dependencies
+RUN dnf install -y cpio less wget gcc make pkgconfig zlib-devel bzip2-devel check-devel libtool-ltdl-devel
 
-# Download libraries we need to run in lambda
-WORKDIR /var/cache/dnf
-RUN dnf download clamav clamav-lib clamav-update json-c pcre2 pcre libprelude gnutls libtasn1 nettle openssl-libs
-
-RUN rpm2cpio clamav*.rpm | cpio -idmv
-RUN rpm2cpio clamav-lib*.rpm | cpio -idmv
-RUN rpm2cpio lib* | cpio -idmv
-RUN rpm2cpio clamav-update*.rpm | cpio -idmv
-RUN rpm2cpio json-c*.rpm | cpio -idmv
-RUN rpm2cpio pcre-*.rpm | cpio -idmv
-RUN rpm2cpio pcre2-*.rpm | cpio -idmv
-RUN rpm2cpio gnutls*.rpm | cpio -idmv
-RUN rpm2cpio libtasn1*.rpm | cpio -idmv
-RUN rpm2cpio nettle*.rpm | cpio -idmv
-RUN rpm2cpio openssl*.rpm | cpio -idmv
-
-# Copy over the binaries and libraries
+# Create directories for ClamAV
 WORKDIR /tmp
-RUN mkdir /clamav
-RUN cp /var/cache/dnf/usr/bin/clamscan /var/cache/dnf/usr/bin/freshclam /var/cache/dnf/usr/lib64/* /clamav -r
+RUN mkdir -p /clamav/bin /clamav/lib
 
-# Fix the freshclam.conf settings
+# Download ClamAV RPM directly - version 1.4.3
+RUN wget -O /tmp/clamav.rpm https://www.clamav.net/downloads/production/clamav-1.4.3.linux.aarch64.rpm && \
+    mkdir -p /tmp/clamav_extract && \
+    cd /tmp/clamav_extract && \
+    rpm2cpio /tmp/clamav.rpm | cpio -idmv && \
+    cp usr/local/bin/clamscan /clamav/bin/ && \
+    cp usr/local/bin/freshclam /clamav/bin/ && \
+    cp -r usr/local/lib64/* /clamav/lib/ && \
+    chmod +x /clamav/bin/clamscan /clamav/bin/freshclam && \
+    rm -rf /tmp/clamav.rpm /tmp/clamav_extract
+
+# Download system dependencies
+WORKDIR /var/cache/dnf
+RUN dnf download json-c pcre2 pcre libprelude gnutls libtasn1 nettle openssl-libs
+
+# Extract system packages
+RUN rpm2cpio json-c*.rpm | cpio -idmv || true
+RUN rpm2cpio pcre-*.rpm | cpio -idmv || true
+RUN rpm2cpio pcre2-*.rpm | cpio -idmv || true
+RUN rpm2cpio gnutls*.rpm | cpio -idmv || true
+RUN rpm2cpio libtasn1*.rpm | cpio -idmv || true
+RUN rpm2cpio nettle*.rpm | cpio -idmv || true
+RUN rpm2cpio openssl*.rpm | cpio -idmv || true
+
+# Copy needed libraries
+RUN cp -r /var/cache/dnf/usr/lib64/* /clamav/lib/ || true
+
+# Fix the freshclam.conf settings for ClamAV 1.4.3
 RUN echo "DatabaseMirror database.clamav.net" > /clamav/freshclam.conf && \
-    echo "CompressLocalDatabase yes" >> /clamav/freshclam.conf
+    echo "CompressLocalDatabase yes" >> /clamav/freshclam.conf && \
+    echo "ScriptedUpdates yes" >> /clamav/freshclam.conf && \
+    echo "Bytecode yes" >> /clamav/freshclam.conf && \
+    echo "DNSDatabaseInfo current.cvd.clamav.net" >> /clamav/freshclam.conf && \
+    echo "ConnectTimeout 60" >> /clamav/freshclam.conf && \
+    echo "ReceiveTimeout 60" >> /clamav/freshclam.conf && \
+    echo "DatabaseOwner root" >> /clamav/freshclam.conf && \
+    echo "DatabaseDirectory /tmp/clamav" >> /clamav/freshclam.conf
 
 
 FROM 118455887602.dkr.ecr.us-west-2.amazonaws.com/releases/images/python311-base-legacy:20250921101147-b4280839
@@ -55,11 +72,11 @@ WORKDIR /var/task
 COPY --chown=upgrade:upgrade --from=build-image /app/*.py /var/task
 COPY --chown=upgrade:upgrade --from=build-image /app/requirements.txt /var/task/requirements.txt
 COPY --chown=upgrade:upgrade --from=build-image /app/custom_clamav_rules /var/task/bin/custom_clamav_rules
-COPY --chown=upgrade:upgrade --from=clamav-image /clamav /var/task/bin
+COPY --chown=upgrade:upgrade --from=clamav-image /clamav /var/task
 
 # Loading all shared libraries
-RUN mkdir /var/task/lib
-RUN cp /var/task/bin/* /var/task/lib -r
+RUN mkdir -p /var/task/lib
+RUN cp /var/task/bin/* /var/task/lib/ && cp /var/task/lib/* /var/task/lib/ || true
 ENV LD_LIBRARY_PATH=/var/task/lib
 RUN ldconfig
 


### PR DESCRIPTION
```
b"ClamAV update process started at Wed Oct  1 16:06:39 2025\nWARNING: Your ClamAV installation is OUTDATED!\nWARNING: Local version: 0.103.11 Recommended version: 1.0.9\nDON'T PANIC! Read https://docs.clamav.net/manual/Installing.html\ndaily database available for download (remote version: 27779)\nWARNING: Can't download daily.cvd from https://database.clamav.net/daily.cvd\nWARNING: FreshClam received error code 403 from the ClamAV Content Delivery Network (CDN).\nThis could mean several things:\n 1. You are running an out-of-date version of ClamAV / FreshClam.\n    Ensure you are the most updated version by visiting https://www.clamav.net/downloads\n 2. Your network is explicitly denied by the FreshClam CDN.\n    In order to rectify this please check that you are:\n   a. Running an up-to-date version of FreshClam\n   b. Running FreshClam no more than once an hour\n   c. If you have checked (a) and (b), please open a ticket at\n      https://github.com/Cisco-Talos/clamav/issues\n      and we will investigate why your network is blocked.\nWARNING: You are on cool-down until after: 2025-10-02 16:06:39\nERROR: Database update process failed: Forbidden; Blocked by CDN\nERROR: Update failed.\n"
```
latest version lts from the website https://www.clamav.net/downloads is 1.4.3.
I can get the definition locally.